### PR TITLE
Update library-chart to support routing to OAuth2 proxy

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 0.0.1
+version: 0.2.0
 type: library

--- a/charts/library-chart/templates/_service.tpl
+++ b/charts/library-chart/templates/_service.tpl
@@ -14,8 +14,8 @@ spec:
   clusterIP: {{ .Values.networking.clusterIP }}
   {{- end }}
   ports:
-    - port: {{ .Values.networking.service.port }}
-      targetPort: {{ .Values.networking.service.port }}
+    - port: {{ if .Values.security.oauth2.enabled }}4180{{ else }}{{ .Values.networking.service.port }}{{ end }}
+      targetPort: {{ if .Values.security.oauth2.enabled }}4180{{ else }}{{ .Values.networking.service.port }}{{ end }}
       protocol: TCP
       name: main
     {{ if .Values.networking.user.enabled }}

--- a/charts/library-chart/templates/_virtualservice.tpl
+++ b/charts/library-chart/templates/_virtualservice.tpl
@@ -34,10 +34,11 @@ spec:
         - destination:
             host: {{ $fullName }}
             port:
-              number: {{ $svcPort }}
+              number:  {{ if .Values.security.oauth2.enabled }}4180{{ else }}{{ $svcPort }}{{ end }}
 {{- end }}
 {{- end }}
 
+# CONSIDER DISABLE IF .Values.security.oauth2.enabled?
 {{/* Template to generate a custom VirtualService */}}
 {{- define "library-chart.virtualserviceUser" -}}
 {{- if .Values.istio.enabled -}}


### PR DESCRIPTION
When security.oauth2 is enabled traffic will be directed to port 4180.