### PR TITLE
mlflow - add oauth2 config and set enabled to false

### DIFF
--- a/charts/mlflow-dapla/values.schema.json
+++ b/charts/mlflow-dapla/values.schema.json
@@ -184,6 +184,16 @@
                 "overwriteDefaultWith": "region.defaultIpProtection"
               }
             },
+            "oauth2": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Enable or disable OAuth2 proxy."
+                }
+              }
+            },
             "ip": {
               "type": "string",
               "description": "the white list of IP is whitespace",

--- a/charts/mlflow-dapla/values.yaml
+++ b/charts/mlflow-dapla/values.yaml
@@ -47,6 +47,8 @@ security:
   allowlist:
     enabled: true
     ip: "0.0.0.0/0"
+  oauth2:
+    enabled: false
   serviceEntry:
     enabled: true
     hosts:


### PR DESCRIPTION
/usr/local/bin/helm upgrade --install mlflow-dapla-71704 dapla-lab-services/mlflow-dapla -n user-ssb-dapla-test1 -f /tmp/values741983189995098381.yaml --output json

Error: template: mlflow-dapla/templates/virtualservice.yaml:1:3: executing "mlflow-dapla/templates/virtualservice.yaml" at <include "library-chart.virtualservice" .>: error calling include: template: mlflow-dapla/charts/library-chart/templates/_virtualservice.tpl:37:36: executing "library-chart.virtualservice" at <.Values.security.oauth2.enabled>: nil pointer evaluating interface {}.enabled