### PR TITLE
Fix oauth2proxy injection of authenticated emails

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.0.0-alpha2
+version: 1.0.0-alpha3
 type: library

--- a/charts/library-chart/templates/_configmapoauth2.tpl
+++ b/charts/library-chart/templates/_configmapoauth2.tpl
@@ -19,7 +19,7 @@ metadata:
     {{- include "library-chart.labels" . | nindent 4 }}
 data:
   oauth2-proxy-authenticated-emails.yaml: |-
-    {{- range .Values.security.oauth2.authenticatedEmails  }}
+    {{- range (splitList "," .Values.security.oauth2.authenticatedEmails)  }}
     {{ . }}
     {{- end }}
   oauth2-proxy-client-config.yaml: |-


### PR DESCRIPTION
Make authenticatedEmails a comma seperated string, to make it easier to inject values into from onyxia