### PR TITLE
Datadoc change port and remove default dataset path

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.19
+version: 0.2.20
 
 dependencies:
   - name: library-chart

--- a/charts/datadoc/values.schema.json
+++ b/charts/datadoc/values.schema.json
@@ -10,7 +10,7 @@
           "title": "Dataset path",
           "type": "string",
           "description": "Path to a dataset file in a GCS bucket. Must start with 'gs://'. Supported file types are .parquet, .parquet.gzip, .sas7bdat.",
-          "default": "gs://ssb-staging-dapla-felles-data-delt/datadoc/klargjorte_data/person_data_v1.parquet"
+          "default": ""
         }
       }
     },
@@ -374,7 +374,7 @@
                           "value": false,
                           "path": "networking/user/enabled"
                       },
-                      "default": 5000
+                      "default": 8050
                   }
               }
           }


### PR DESCRIPTION
- Changed port from 5000 to 8050 to match datadoc
- Removed default dataset path, to an empty string