### PR TITLE
Use SSB customized vscode image

### DIFF
--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.3
+version: 2.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python/templates/statefulset.yaml
+++ b/charts/vscode-python/templates/statefulset.yaml
@@ -80,7 +80,7 @@ spec:
           {{- end }} 
           command: ["/bin/sh","-c"]
           {{- $authMethod := ternary "none" "password" .Values.security.oauth2.enabled }}
-          args: ["/usr/bin/code-server --host 0.0.0.0 --auth {{ $authMethod }} /home/{{ .Values.environment.user }}/work"]
+          args: ["/usr/bin/code-server --host 0.0.0.0 --auth {{ $authMethod }} /home/coder/work"]
           imagePullPolicy: {{ .Values.service.image.pullPolicy }}
           env:
             {{- if .Values.init.regionInit }}

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -150,10 +150,8 @@
               "version": {
                 "description": "vscode supported version",
                 "type": "string",
-                "default": "inseefrlab/onyxia-vscode-python:py3.10.9",
+                "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/dapla-vscode-python:main",
                 "listEnum": [
-                  "inseefrlab/onyxia-vscode-python:py3.10.9",
-                  "inseefrlab/onyxia-vscode-python:py3.9.16",
                   "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/dapla-vscode-python:main"
                 ],
                 "render": "list",


### PR DESCRIPTION
This PR restricts the available options in DaplaLab when launching VSCode Python to exclusively support the use of [dapla-vscode-python](https://github.com/statisticsnorway/dapla-vscode-python) image.