### PR TITLE
VScode: Revert Changes to Enable Execution of Init Script

### DIFF
--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python/templates/statefulset.yaml
+++ b/charts/vscode-python/templates/statefulset.yaml
@@ -80,7 +80,7 @@ spec:
           {{- end }} 
           command: ["/bin/sh","-c"]
           {{- $authMethod := ternary "none" "password" .Values.security.oauth2.enabled }}
-          args: ["/usr/bin/code-server --host 0.0.0.0 --auth {{ $authMethod }} /home/coder/work"]
+          args: ["{{ .Values.init.standardInitPath }} /usr/bin/code-server --host 0.0.0.0 --auth {{ $authMethod }} /home/coder/work"]
           imagePullPolicy: {{ .Values.service.image.pullPolicy }}
           env:
             {{- if .Values.init.regionInit }}

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -28,7 +28,7 @@ security:
     authenticatedEmails: ""
 
 init:
-  standardInitPath: ""
+  standardInitPath: "/opt/onyxia-init.sh"
   regionInit: ""
   regionInitCheckSum: ""
   personalInit: ""


### PR DESCRIPTION
As of commit https://github.com/statisticsnorway/dapla-vscode-python/commit/51bd3d9b7975ec28b7b541ffa1c0fd297e5ce1fa, the Dapla VSCode images now include an init script.

This PR reverts previous changes to enable the execution of the init script.
This effectively reverts: [#58](https://github.com/statisticsnorway/dapla-lab-helm-charts-services/pull/58/files)