### PR TITLE
Update image for jupyter-python-dapla

### DIFF
--- a/charts/jupyter-python-dapla/Chart.yaml
+++ b/charts/jupyter-python-dapla/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-python-dapla/values.schema.json
+++ b/charts/jupyter-python-dapla/values.schema.json
@@ -20,13 +20,12 @@
                         "description": "supported versions",
                         "type": "string",
                         "listEnum": [
-                            "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/jupyter-python-dapla:latest",
-                            "jupyter/scipy-notebook:lab-4.0.3",
-                            "inseefrlab/onyxia-jupyter-python:py3.10.9"
+                            "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-stat-docker/jupyter/jupyterlab-dapla:v1",
+                            "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-stat-docker/jupyter/jupyterlab-dapla:latest"
                         ],
                         "render": "list",
                         "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
-                        "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/jupyter-python-dapla:latest"
+                        "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-stat-docker/jupyter/jupyterlab-dapla:v1"
                       }
                     }
                 }

--- a/charts/jupyter-python-dapla/values.yaml
+++ b/charts/jupyter-python-dapla/values.yaml
@@ -2,7 +2,7 @@
 
 service:
   image:
-    version: "eu.gcr.io/prod-bip/ssb/dapla/dapla-jupyterlab:merge-168a792271455b401e1ea1a4270061d656ea1273"
+    version: "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-stat-docker/jupyter/jupyterlab-dapla:v1"
     pullPolicy: IfNotPresent
 
 security:


### PR DESCRIPTION
The `v1` tag is updated to the latest v1.x.x each time a release is run. Allow choosing the latest image for testing purposes.

Ref: DPSTAT-676