### PR TITLE
refactored service options

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.23
+version: 0.2.24
 
 dependencies:
   - name: library-chart

--- a/charts/datadoc/templates/NOTES.txt
+++ b/charts/datadoc/templates/NOTES.txt
@@ -5,4 +5,3 @@
 If you don't run your custom service you will get a 502 bad gateway error.
 {{- end }}
 {{- end }}
-- Your access token is **{{ .Values.security.password }}**

--- a/charts/datadoc/values.schema.json
+++ b/charts/datadoc/values.schema.json
@@ -36,10 +36,14 @@
               ]
             },
             "version": {
-              "description": "supported versions",
+              "description": "datadoc supported versions",
               "type": "string",
+              "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/datadoc:master",
+              "listEnum": [
+                "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/datadoc:master"
+              ],
               "render": "list",
-              "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/datadoc:master"
+              "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$"
             }
           }
         }
@@ -175,6 +179,7 @@
           "description": "Password",
           "default": "changeme",
           "render": "password",
+          "hidden": true,
           "x-onyxia": {
             "overwriteDefaultWith": "{{project.password}}"
           }
@@ -188,6 +193,7 @@
               "title": "Enable IP protection",
               "description": "Only the configured set of IPs will be able to reach the service",
               "default": true,
+              "hidden": true,
               "x-onyxia": {
                 "overwriteDefaultWith": "region.defaultIpProtection"
               }
@@ -215,6 +221,7 @@
               "title": "Enable network policy",
               "description": "Only pod from the same namespace will be allowed",
               "default": true,
+              "hidden": true,
               "x-onyxia": {
                 "overwriteDefaultWith": "region.defaultNetworkPolicy"
               }
@@ -238,7 +245,8 @@
               "type": "boolean",
               "title": "Enable service entry",
               "description": "Enable access to external services",
-              "default": true
+              "default": true,
+              "hidden": true
             },
             "hosts": {
               "type": "array",
@@ -364,7 +372,8 @@
                       "type": "boolean",
                       "title": "Enable a custom service port",
                       "description": "Enable a custom service port",
-                      "default": false
+                      "default": false,
+                      "hidden": true
                   },
                   "port": {
                       "type": "integer",

--- a/charts/datadoc/values.schema.json
+++ b/charts/datadoc/values.schema.json
@@ -174,16 +174,6 @@
       "description": "security specific configuration",
       "type": "object",
       "properties": {
-        "password": {
-          "type": "string",
-          "description": "Password",
-          "default": "changeme",
-          "render": "password",
-          "hidden": true,
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{project.password}}"
-          }
-        },
         "allowlist": {
           "type": "object",
           "description": "IP protection",

--- a/charts/jupyter-python-dapla/Chart.yaml
+++ b/charts/jupyter-python-dapla/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.4
+version: 1.1.5
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-python-dapla/templates/NOTES.txt
+++ b/charts/jupyter-python-dapla/templates/NOTES.txt
@@ -1,7 +1,6 @@
 {{- if .Values.istio.enabled }}
 - You can connect to this jupyter with your browser on this [link](https://{{ .Values.istio.hostname }})
 {{- end }}
-- Your access token is **{{ .Values.security.password }}**
 
 *NOTES about deletion :*
 

--- a/charts/jupyter-python-dapla/templates/statefulset.yaml
+++ b/charts/jupyter-python-dapla/templates/statefulset.yaml
@@ -88,11 +88,7 @@ spec:
             - name: NB_USER
               value: {{ .Values.environment.user }}
             - name: PASSWORD
-              {{- if .Values.security.oauth2.enabled}}
               value: ""
-              {{- else }}
-              value: {{ .Values.security.password }}
-              {{- end }}
             - name: PROJECT_USER
               value: {{ .Values.environment.user }}
             - name: PROJECT_GROUP

--- a/charts/jupyter-python-dapla/values.schema.json
+++ b/charts/jupyter-python-dapla/values.schema.json
@@ -39,19 +39,22 @@
                 "type": "boolean",
                 "title": "Enable hive metastore discovery",
                 "description": "discover your hive metastore service",
-                "default": true
+                "default": true,
+                "hidden": true
               },
               "mlflow": {
                 "type": "boolean",
                 "title": "Enable mlflow discovery",
                 "description": "discover your mlflow service",
-                "default": true
+                "default": true,
+                "hidden": true
               },
               "metaflow": {
                 "type": "boolean",
                 "title": "Enable metaflow discovery",
                 "description": "discover your metaflow service",
-                "default": true
+                "default": true,
+                "hidden": true
               }
             }
         },
@@ -185,6 +188,7 @@
                     "description": "Password",
                     "default": "changeme",
                     "render": "password",
+                    "hidden": true,
                     "x-onyxia": {
                         "overwriteDefaultWith": "{{project.password}}"
                     }
@@ -198,6 +202,7 @@
                         "title": "Enable IP protection",
                         "description": "Only the configured set of IPs will be able to reach the service",
                         "default": true,
+                        "hidden": true,
                         "x-onyxia": {
                             "overwriteDefaultWith": "region.defaultIpProtection"
                         }
@@ -225,6 +230,7 @@
                         "title": "Enable network policy",
                         "description": "Only pod from the same namespace will be allowed",
                         "default": true,
+                        "hidden": true,
                         "x-onyxia": {
                             "overwriteDefaultWith": "region.defaultNetworkPolicy"
                         }
@@ -248,7 +254,8 @@
                       "type": "boolean",
                       "title": "Enable service entry",
                       "description": "Enable access to external services",
-                      "default": true
+                      "default": true,
+                      "hidden": true
                     },
                     "hosts": {
                       "type": "array",
@@ -487,7 +494,8 @@
                     "type": "boolean",
                     "title": "Enable a custom service port",
                     "description": "Enable a custom service port",
-                    "default": false
+                    "default": false,
+                    "hidden": true
                   },
                   "port": {
                     "type": "integer",

--- a/charts/jupyter-python-dapla/values.schema.json
+++ b/charts/jupyter-python-dapla/values.schema.json
@@ -183,16 +183,6 @@
             "description": "security specific configuration",
             "type": "object",
             "properties": {
-                "password": {
-                    "type": "string",
-                    "description": "Password",
-                    "default": "changeme",
-                    "render": "password",
-                    "hidden": true,
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{project.password}}"
-                    }
-                },
                 "allowlist": {
                     "type": "object",
                     "description": "IP protection",

--- a/charts/mlflow-dapla/Chart.yaml
+++ b/charts/mlflow-dapla/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.0.2
+version: 1.0.3
 
 dependencies:
   - name: postgresql

--- a/charts/mlflow-dapla/templates/NOTES.txt
+++ b/charts/mlflow-dapla/templates/NOTES.txt
@@ -1,7 +1,6 @@
 {{- if .Values.istio.enabled }}
 - You can connect to the mlflow UI with your browser on this [link](https://{{ .Values.istio.hostname }})
 {{- end }}
-- Your access token is **{{ .Values.security.password }}**
 
 *NOTES about deletion :*
 

--- a/charts/mlflow-dapla/values.schema.json
+++ b/charts/mlflow-dapla/values.schema.json
@@ -74,14 +74,6 @@
       "description": "security specific configuration",
       "type": "object",
       "properties": {
-        "password": {
-          "type": "string",
-          "description": "Password",
-          "default": "changeme",
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{project.password}}"
-          }
-        },
         "allowlist": {
           "type": "object",
           "description": "IP protection",

--- a/charts/mlflow-dapla/values.schema.json
+++ b/charts/mlflow-dapla/values.schema.json
@@ -52,6 +52,7 @@
           "description": "Enable route",
           "type": "boolean",
           "default": false,
+          "hidden": true,
           "x-onyxia": {
             "hidden": false,
             "overwriteDefaultWith": "k8s.route"
@@ -61,6 +62,7 @@
           "type": "string",
           "form": true,
           "title": "Hostname",
+          "hidden": true,
           "x-onyxia": {
             "hidden": false,
             "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
@@ -142,7 +144,8 @@
           "type": "boolean",
           "title": "Enable service entry",
           "description": "Enable access to external services",
-          "default": true
+          "default": true,
+          "hidden": true
         },
         "hosts": {
           "type": "array",
@@ -297,6 +300,7 @@
               "type": "string",
               "title": "User",
               "default": "user",
+              "hidden": true,
               "x-onyxia": {
                 "overwriteDefaultWith": "{{project.id}}"
               }
@@ -305,6 +309,7 @@
               "type": "string",
               "title": "User Password",
               "default": "changeme",
+              "hidden": true,
               "x-onyxia": {
                 "overwriteDefaultWith": "{{project.password}}"
               }
@@ -313,6 +318,7 @@
               "type": "string",
               "title": "Admin Password",
               "default": "changeme",
+              "hidden": true,
               "x-onyxia": {
                 "overwriteDefaultWith": "{{project.password}}"
               }

--- a/charts/rstudio-dapla/Chart.yaml
+++ b/charts/rstudio-dapla/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio-dapla/templates/NOTES.txt
+++ b/charts/rstudio-dapla/templates/NOTES.txt
@@ -2,9 +2,6 @@
 - You can connect to this rstudio with your browser on this [link](https://{{ .Values.istio.hostname }})
 {{- end }}
 
-- The login is **{{ .Values.environment.user }}**
-- The password is **{{ .Values.security.password }}**
-
 *NOTES about deletion :*
 
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}

--- a/charts/rstudio-dapla/templates/statefulset.yaml
+++ b/charts/rstudio-dapla/templates/statefulset.yaml
@@ -67,7 +67,7 @@ spec:
             - name: IMAGE_NAME
               value: "{{ .Values.service.image.version }}"
             - name: PASSWORD
-              value: {{ .Values.security.password }}
+              value: ""
             - name: PROJECT_USER
               value: {{ .Values.environment.user }}
             - name: PROJECT_GROUP

--- a/charts/rstudio-dapla/values.schema.json
+++ b/charts/rstudio-dapla/values.schema.json
@@ -161,16 +161,6 @@
             "description": "RStudio specific configuration",
             "type": "object",
             "properties": {
-                "password": {
-                    "type": "string",
-                    "description": "Password",
-                    "default": "changeme",
-                    "render": "password",
-                    "hidden": true,
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{project.password}}"
-                    }
-                },
                 "allowlist": {
                     "type": "object",
                     "description": "IP protection",

--- a/charts/rstudio-dapla/values.schema.json
+++ b/charts/rstudio-dapla/values.schema.json
@@ -166,6 +166,7 @@
                     "description": "Password",
                     "default": "changeme",
                     "render": "password",
+                    "hidden": true,
                     "x-onyxia": {
                         "overwriteDefaultWith": "{{project.password}}"
                     }
@@ -179,6 +180,7 @@
                             "title": "Enable IP protection",
                             "description": "Only the configured set of IPs will be able to reach the service",
                             "default": true,
+                            "hidden": true,
                             "x-onyxia": {
                                 "overwriteDefaultWith": "region.defaultIpProtection"
                             }
@@ -206,6 +208,7 @@
                             "title": "Enable network policy",
                             "description": "Only pod from the same namespace will be allowed",
                             "default": true,
+                            "hidden": true,
                             "x-onyxia": {
                                 "overwriteDefaultWith": "region.defaultNetworkPolicy"
                             }
@@ -229,7 +232,8 @@
                             "type": "boolean",
                             "title": "Enable service entry",
                             "description": "Enable access to external services",
-                            "default": true
+                            "default": true,
+                            "hidden": true
                         },
                         "hosts": {
                             "type": "array",
@@ -503,7 +507,8 @@
                             "type": "boolean",
                             "title": "Enable a custom service port",
                             "description": "Enable a custom service port",
-                            "default": false
+                            "default": false,
+                            "hidden": true
                         },
                         "port": {
                             "type": "integer",

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.3
+version: 2.0.4
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python/README.md
+++ b/charts/vscode-python/README.md
@@ -32,8 +32,6 @@ The Visual Studio Code IDE with Python, Julia, and a collection of standard data
 | discovery.mlflow | bool | `true` |  |
 | environment.group | string | `"users"` |  |
 | environment.user | string | `"onyxia"` |  |
-| fauxpilot.enabled | bool | `false` |  |
-| fauxpilot.server | string | `"http://fauxpilot-proxy.fauxpilot:5000/v1/engines"` |  |
 | fullnameOverride | string | `""` |  |
 | git.branch | string | `""` |  |
 | git.cache | string | `""` |  |

--- a/charts/vscode-python/templates/NOTES.txt
+++ b/charts/vscode-python/templates/NOTES.txt
@@ -1,4 +1,3 @@
 {{- if .Values.istio.enabled }}
 - You can connect to this vscode with your browser on this [link](https://{{ .Values.istio.hostname }})
 {{- end }}
-- Your access token is **{{ .Values.security.password }}**

--- a/charts/vscode-python/templates/statefulset.yaml
+++ b/charts/vscode-python/templates/statefulset.yaml
@@ -103,10 +103,6 @@ spec:
               value: {{ .Values.environment.group }}
             - name: ROOT_PROJECT_DIRECTORY
               value: /home/{{ .Values.environment.user }}/work  
-            {{- if  .Values.fauxpilot.enabled }}
-            - name: FAUXPILOT_SERVER
-              value: "{{ .Values.fauxpilot.server }}" 
-            {{- end }}
           envFrom:
             {{- if .Values.oidc.enabled }}
             - configMapRef:

--- a/charts/vscode-python/templates/statefulset.yaml
+++ b/charts/vscode-python/templates/statefulset.yaml
@@ -96,7 +96,7 @@ spec:
               value: {{ .Values.init.personalInitArgs }}
             {{- end }}
             - name: PASSWORD
-              value: {{ .Values.security.password }}  
+              value: ""
             - name: PROJECT_USER
               value: {{ .Values.environment.user }}
             - name: PROJECT_GROUP

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -182,19 +182,6 @@
       "description": "security specific configuration",
       "type": "object",
       "properties": {
-        "password": {
-          "type": "string",
-          "description": "Password",
-          "default": "changeme",
-          "render": "password",
-          "hidden": true,
-          "x-form": {
-            "value": "{{project.password}}"
-          },
-          "x-onyxia": {
-              "overwriteDefaultWith": "{{project.password}}"
-          }
-        },
         "allowlist": {
           "type": "object",
           "description": "IP protection",

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -92,23 +92,6 @@
           }
       }
     },
-    "fauxpilot": {
-    "description": "An extension that is equivalent to Copilot",
-    "type": "object",
-    "properties": {
-      "enabled": {
-        "type": "boolean",
-        "title": "Enable Fauxpilot extension",
-        "default": false
-      },
-      "server": {
-        "type": "string",
-        "title": "Server's URL",
-        "description": "the default URL is hosted on Datalab",
-        "default": "http://fauxpilot-proxy.fauxpilot:5000/v1/engines"
-      }
-    }
-    },
     "discovery": {
       "description": "configure your service to autodetect some ressources.",
       "type": "object",
@@ -117,19 +100,22 @@
           "type": "boolean",
           "title": "Enable hive metastore discovery",
           "description": "discover your hive metastore service",
-          "default": true
+          "default": true,
+          "hidden": true
         },
         "mlflow": {
           "type": "boolean",
           "title": "Enable mlflow discovery",
           "description": "discover your mlflow service",
-          "default": true
+          "default": true,
+          "hidden": true
         },
         "metaflow": {
           "type": "boolean",
           "title": "Enable metaflow discovery",
           "description": "discover your metaflow service",
-          "default": true
+          "default": true,
+          "hidden": true
         }
       }
     },
@@ -159,7 +145,7 @@
               }
             }        
         }
-    }
+      }
     },  
     "persistence": {
       "description": "Configuration for persistence",
@@ -201,6 +187,7 @@
           "description": "Password",
           "default": "changeme",
           "render": "password",
+          "hidden": true,
           "x-form": {
             "value": "{{project.password}}"
           },
@@ -217,6 +204,7 @@
               "title": "Enable IP protection",
               "description": "Only the configured set of IPs will be able to reach the service",
               "default": true,
+              "hidden": true,
               "x-form": {
                 "value": "{{region.defaultIpProtection}}"
               },
@@ -228,6 +216,7 @@
               "type": "string",
               "description": "the white list of IP is whitespace",
               "title": "Whitelist of IP",
+              "hidden": true,
               "x-form": {
                 "value": "{{user.ip}}"
               },
@@ -246,6 +235,7 @@
               "title": "Enable network policy",
               "description": "Only pod from the same namespace will be allowed",
               "default": true,
+              "hidden": true,
               "x-form": {
                 "value": "{{region.defaultNetworkPolicy}}"
               },
@@ -276,7 +266,8 @@
               "type": "boolean",
               "title": "Enable service entry",
               "description": "Enable access to external services",
-              "default": true
+              "default": true,
+              "hidden": true
             },
             "hosts": {
               "type": "array",
@@ -560,7 +551,8 @@
               "type": "boolean",
               "title": "Enable a custom service port",
               "description": "Enable a custom service port",
-              "default": false
+              "default": false,
+              "hidden": true
             },
             "port": {
               "type": "integer",

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -61,9 +61,6 @@ coresite:
 metaflow:
   configMapName: ""
 
-fauxpilot:
-  enabled: false
-  server: "http://fauxpilot-proxy.fauxpilot:5000/v1/engines"
 
 git:
   # Specifies whether a config map should be created


### PR DESCRIPTION
- Hides service options that users should not need to modify.
- Removed fauxpilot tab for vscode-python
- Fixed service tab crashing for datadoc