### PR TITLE
Remove support for Values.security.oauth2.enabled.

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.0.1
+version: 2.0.0
 type: library

--- a/charts/library-chart/templates/_configmapoauth2.tpl
+++ b/charts/library-chart/templates/_configmapoauth2.tpl
@@ -1,16 +1,11 @@
 {{/* Create the name of the config map oauth2proxy to use */}}
 {{- define "library-chart.configMapNameOAuth2" -}}
-{{- if .Values.security.oauth2.enabled }}
 {{- $name:= (printf "%s-configmap-oauth2" (include "library-chart.fullname" .) )  }}
 {{- default $name .Values.security.oauth2.configMapName }}
-{{- else }}
-{{- default "oauth2-proxy-client-config" .Values.security.oauth2.configMapName }}
-{{- end }}
 {{- end }}
 
 {{/* Template to generate a ConfigMap for oauth2proxy */}}
 {{- define "library-chart.configMapOAuth2" -}}
-{{- if .Values.security.oauth2.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -142,5 +137,4 @@ data:
     reverse_proxy = true
     real_client_ip_header = "X-Forwarded-For"
 
-{{- end }}
 {{- end }}

--- a/charts/library-chart/templates/_dapla_common_redirect_uri.tpl
+++ b/charts/library-chart/templates/_dapla_common_redirect_uri.tpl
@@ -1,10 +1,6 @@
 {{- define "library-chart.daplaCommonClientRedirectUriName" -}}
-{{- if .Values.security.oauth2.enabled }}
 {{- $name:= (printf "%s-client-redirect-uri" (include "library-chart.fullname" .) )  }}
 {{- default $name .Values.security.oauth2.daplaCommonClientRedirectUriName }}
-{{- else }}
-{{- default "default" .Values.security.oauth2.daplaCommonClientRedirectUriName }}
-{{- end }}
 {{- end }}
 
 {{- define "library-chart.daplaCommonClientRedirectUriSecretName" -}}
@@ -13,7 +9,6 @@
 {{- end }}
 
 {{- define "library-chart.daplaCommonClientRedirectUri" -}}
-{{- if .Values.security.oauth2.enabled }}
 apiVersion: dapla.ssb.no/v1alpha1
 kind: CommonClientRedirectUri
 metadata:
@@ -25,5 +20,4 @@ spec:
   redirectUri: "https://{{ .Values.istio.hostname }}/oauth2/callback"
   secretName: {{ include "library-chart.daplaCommonClientRedirectUriSecretName" . | quote }}
 
-{{- end }}
 {{- end }}

--- a/charts/library-chart/templates/_service.tpl
+++ b/charts/library-chart/templates/_service.tpl
@@ -14,18 +14,10 @@ spec:
   clusterIP: {{ .Values.networking.clusterIP }}
   {{- end }}
   ports:
-    - port: {{ if .Values.security.oauth2.enabled }}4180{{ else }}{{ .Values.networking.service.port }}{{ end }}
-      targetPort: {{ if .Values.security.oauth2.enabled }}4180{{ else }}{{ .Values.networking.service.port }}{{ end }}
+    - port: 4180
+      targetPort: 4180
       protocol: TCP
       name: main
-    {{ if .Values.spark }}
-    {{ if .Values.spark.sparkui }}
-    - port: {{ .Values.networking.sparkui.port }}
-      targetPort: {{ .Values.networking.sparkui.port }}
-      protocol: TCP
-      name: sparkui
-    {{- end }}
-    {{- end }}
   selector:
     {{- include "library-chart.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/library-chart/templates/_virtualservice.tpl
+++ b/charts/library-chart/templates/_virtualservice.tpl
@@ -30,6 +30,6 @@ spec:
         - destination:
             host: {{ $fullName }}
             port:
-              number:  {{ if .Values.security.oauth2.enabled }}4180{{ else }}{{ $svcPort }}{{ end }}
+              number: 4180
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Oauth2 proxy is enabled by default for services who use this library chart.

Internal ref: [DPSKY-502]

[DPSKY-502]: https://statistics-norway.atlassian.net/browse/DPSKY-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ