### PR TITLE
Bump Vscode image to v1.0.1

### DIFF
--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.2
+version: 2.4.3
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -109,9 +109,9 @@
               "version": {
                 "description": "vscode supported version",
                 "type": "string",
-                "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/dapla-vscode-python:v1.0.0",
+                "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/dapla-vscode-python:v1.0.1",
                 "listEnum": [
-                  "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/dapla-vscode-python:v1.0.0"
+                  "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/dapla-vscode-python:v1.0.1"
                 ],
                 "render": "list",
                 "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$"


### PR DESCRIPTION
Contains changes from: https://github.com/statisticsnorway/dapla-vscode-python/pull/16