### PR TITLE
Fix type error for delteJob.enabled

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 dependencies:
   - name: library-chart

--- a/charts/datadoc/values.schema.json
+++ b/charts/datadoc/values.schema.json
@@ -460,7 +460,7 @@
         "enabled": {
           "type": "boolean",
           "description": "Whenever or not to create a job to delete this release",
-          "default": "true",
+          "default": true,
           "x-onyxia": {
             "hidden": false
           }

--- a/charts/jupyter-dapla/Chart.yaml
+++ b/charts/jupyter-dapla/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.4
+version: 1.4.5
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-dapla/values.schema.json
+++ b/charts/jupyter-dapla/values.schema.json
@@ -630,7 +630,7 @@
           "enabled": {
             "type": "boolean",
             "description": "Whenever or not to create a job to delete this release",
-            "default": "true",
+            "default": true,
             "x-onyxia": {
               "hidden": false
             }

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.2
+version: 1.4.3
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -610,7 +610,7 @@
                 "enabled": {
                     "type": "boolean",
                     "description": "Whenever or not to create a job to delete this release",
-                    "default": "true",
+                    "default": true,
                     "x-onyxia": {
                         "hidden": false
                     }

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.2
+version: 2.5.3
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -666,7 +666,7 @@
         "enabled": {
           "type": "boolean",
           "description": "Whenever or not to create a job to delete this release",
-          "default": "true",
+          "default": true,
           "x-onyxia": {
             "hidden": false
           }


### PR DESCRIPTION
deleteJob.enabled defaulted to a string value, this causes the following error for all charts. Resulting in no services being able to start.

```
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
datadoc:
- deleteJob.enabled: Invalid type. Expected: boolean, given: string
```
