### PR TITLE
Remove security tab from 'rstudio' configuration UI

### DIFF
--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.4
+version: 1.4.5-alpha
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -182,10 +182,6 @@
                             "x-onyxia": {
                                 "hidden": true,
                                 "overwriteDefaultWith": "{{user.ip}}"
-                            },
-                            "hidden": {
-                                "value": true,
-                                "path": "security/allowlist/enabled"
                             }
                         }
                     }


### PR DESCRIPTION
The 'ip' property is not being hidden despite `x-onyxia`'s hidden parameter being set to true, ref https://github.com/statisticsnorway/dapla-lab-helm-charts-services/blob/a9ad0c81340e8edaf4325becd11973e2424ca757/charts/rstudio/values.schema.json#L182C29-L182C29
```
"x-onyxia": {
    "hidden": true, ...}
```
This might be because the 'security/allowlist/enabled' setting is always set to 'True' thereby overwriting x-onyxia hidden. Removing it fixes the issue when testing locally from browser.
