### PR TITLE
Fix volume mount configuration and remove timezone env variable

### DIFF
--- a/charts/jupyter-dapla/Chart.yaml
+++ b/charts/jupyter-dapla/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.8
+version: 1.4.9
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-dapla/templates/statefulset.yaml
+++ b/charts/jupyter-dapla/templates/statefulset.yaml
@@ -77,8 +77,6 @@ spec:
               value: {{ .Values.environment.group }}
             - name: ROOT_PROJECT_DIRECTORY
               value: /home/{{ .Values.environment.user }}/work
-            - name: TZ
-              value: "UTC"
             {{- if .Values.init.regionInit }}
             - name: REGION_INIT_SCRIPT
               value: {{ .Values.init.regionInit }}
@@ -124,7 +122,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - mountPath: /home/{{ .Values.environment.user}}/work
+            - mountPath: /home/{{ .Values.environment.user}}
               name: home
         - {{ include "library-chart.oauth2ProxyPod" . | indent 10 | trim }}
       {{- with .Values.nodeSelector }}

--- a/charts/jupyter-dapla/values.yaml
+++ b/charts/jupyter-dapla/values.yaml
@@ -30,7 +30,7 @@ init:
   personalInitArgs: ""
 
 environment:
-  user: onyxia
+  user: jovyan
   group: users
 
 userAttributes:


### PR DESCRIPTION
Volume should now mount in users home directory($HOME), this should resolve issues related to `jovyan` missing permissions for certain files and folders under $HOME. 

Jira issue: https://statistics-norway.atlassian.net/jira/software/c/projects/DPSTAT/boards/271/backlog?selectedIssue=DPSTAT-793

**Other changes**:
- Remove time zone env var. (no longer needed after changes to Dapla toolbelt)
ref: https://github.com/statisticsnorway/dapla-lab-helm-charts-services/pull/112 && https://github.com/statisticsnorway/dapla-toolbelt/issues/92
