### PR TITLE
Update datadoc image references

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - Classifications
 home: https://github.com/statisticsnorway/datadoc
 sources:
-# A chart can be either an 'application' or a 'library' chart.
+  # A chart can be either an 'application' or a 'library' chart.
   - https://github.com/statisticsnorway/dapla-lab-helm-charts-services
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.5.4
 
 dependencies:
   - name: library-chart

--- a/charts/datadoc/values.schema.json
+++ b/charts/datadoc/values.schema.json
@@ -38,9 +38,9 @@
             "version": {
               "description": "datadoc supported versions",
               "type": "string",
-              "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/datadoc:v0.3.4",
+              "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-metadata-docker/datadoc/datadoc:master",
               "listEnum": [
-                "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/datadoc:v0.3.4"
+                "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-metadata-docker/datadoc/datadoc:v0"
               ],
               "render": "list",
               "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$"
@@ -343,34 +343,34 @@
       "form": true,
       "title": "Networking detail",
       "properties": {
-          "user": {
-              "type": "object",
-              "description": "user defined port",
-              "properties": {
-                  "enabled": {
-                      "type": "boolean",
-                      "title": "Enable a custom service port",
-                      "description": "Enable a custom service port",
-                      "default": false,
-                      "x-onyxia": {
-                        "hidden": true
-                      }
-                  },
-                  "port": {
-                      "type": "integer",
-                      "description": "port of the custom service",
-                      "title": "Custom service port",
-                      "x-onyxia": {
-                        "hidden": true
-                      },
-                      "hidden": {
-                          "value": false,
-                          "path": "networking/user/enabled"
-                      },
-                      "default": 8050
-                  }
+        "user": {
+          "type": "object",
+          "description": "user defined port",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable a custom service port",
+              "description": "Enable a custom service port",
+              "default": false,
+              "x-onyxia": {
+                "hidden": true
               }
+            },
+            "port": {
+              "type": "integer",
+              "description": "port of the custom service",
+              "title": "Custom service port",
+              "x-onyxia": {
+                "hidden": true
+              },
+              "hidden": {
+                "value": false,
+                "path": "networking/user/enabled"
+              },
+              "default": 8050
+            }
           }
+        }
       }
     },
     "userAttributes": {

--- a/charts/datadoc/values.yaml
+++ b/charts/datadoc/values.yaml
@@ -2,8 +2,8 @@
 
 service:
   image:
-    version: "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/datadoc:v0.3.4"
-    pullPolicy: IfNotPresent
+    version: "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-metadata-docker/datadoc/datadoc:master"
+    pullPolicy: Always
 
 security:
   password: "changeme"
@@ -70,7 +70,8 @@ podLabels:
 podSecurityContext:
   fsGroup: 100
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -93,7 +94,8 @@ istio:
   hostname: chart-example.local
   userHostname: chart-example-user.local
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
- Use `dapla-metadata-docker` repo where images are built to now.
- Change the default image reference to `master` to facilitate testing under development.