### PR TITLE
Allow wildcard egress

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 3.2.3
+version: 3.2.4
 type: library

--- a/charts/library-chart/templates/_serviceentry.tpl
+++ b/charts/library-chart/templates/_serviceentry.tpl
@@ -19,6 +19,6 @@ spec:
   - name: https
     number: 443
     protocol: HTTPS
-  resolution: DNS
+  resolution: NONE
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
DNS resolving does not work for wildcard hosts (such as `*.domain.com`). Attempting to configure egress to these types of hosts causes Onyxia to return a 500 (originating from illegal Istio service entries)

This PR disables DNS resolving.

Library-chart version is updated to 3.2.4, remember to update this in downstream charts.